### PR TITLE
2026-05-05 Oat CSS after Pico

### DIFF
--- a/src/content/blog/2026/2026-05-05-oat-css-after-pico.mdx
+++ b/src/content/blog/2026/2026-05-05-oat-css-after-pico.mdx
@@ -4,7 +4,6 @@ description: "Pico CSS is still great for clean semantic pages, but Oat CSS star
 date: 2026-05-05
 slug: "oat-css-after-pico"
 tags: ["css", "frontend", "web-development", "oat-css", "pico-css"]
-hidden: true
 social_post: |
   I still like Pico CSS. But once a page starts acting more like a product, Oat CSS feels like a useful next step: semantic HTML, tiny footprint, and more built-in UI primitives.
 ---


### PR DESCRIPTION
/schedule 2026-05-05T08:00:00Z

## Post Details
- **Title**: Oat CSS after Pico
- **Slug**: oat-css-after-pico
- **Preview URL**: https://mfyzcom-remote.mfyz.net/oat-css-after-pico/?preview=1

This PR removes `hidden: true` from the post frontmatter to publish it.
When merged, the post will become publicly visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Blog post "OAT CSS After Pico" is now publicly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->