### PR TITLE
Schedule DASH 2026 notes post

### DIFF
--- a/src/content/blog/2026/2026-06-16-from-observability-to-action-dash-2026-notes.mdx
+++ b/src/content/blog/2026/2026-06-16-from-observability-to-action-dash-2026-notes.mdx
@@ -4,7 +4,6 @@ description: "Two things stood out to me at Datadog DASH 2026: agentic automatio
 date: 2026-06-16
 slug: "from-observability-to-action-dash-2026-notes"
 tags: ["datadog", "ai", "agents", "observability", "automation"]
-hidden: true
 social_post: |
   Two things stood out to me at Datadog DASH 2026: agentic automation is closing the loop, and agent observability is becoming a real operational discipline.
 ---


### PR DESCRIPTION
Publishes the hidden draft post `from-observability-to-action-dash-2026-notes` by removing `hidden: true`.

/schedule 2026-06-16 09:00

Scheduled time uses the repository merge scheduler timezone: America/New_York.

Validation:
- `npm run check:types` passed before scheduling.
- Preview verified at https://mfyzcom-remote.mfyz.net/from-observability-to-action-dash-2026-notes/?preview=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Blog post "From Observability to Action - DASH 2026 Notes" is now publicly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->