### PR TITLE
Schedule Cloudflare agent apps post

### DIFF
--- a/src/content/blog/2026/2026-06-23-cloudflare-absorbs-voidzero-and-astro-becoming-default-path-agent-apps.mdx
+++ b/src/content/blog/2026/2026-06-23-cloudflare-absorbs-voidzero-and-astro-becoming-default-path-agent-apps.mdx
@@ -4,7 +4,6 @@ description: "Cloudflare absorbing Astro and VoidZero is not just a front-end to
 date: 2026-06-23
 slug: "cloudflare-absorbs-voidzero-and-astro-becoming-default-path-agent-apps"
 tags: ["cloudflare", "astro", "vite", "agents", "developer-tools"]
-hidden: true
 social_post: |
   Cloudflare absorbing Astro and VoidZero is not just a tooling story. It is about owning the path from agent-written code to deployed app.
 ---


### PR DESCRIPTION
Publishes the hidden draft post by removing `hidden: true` from:

`src/content/blog/2026/2026-06-23-cloudflare-absorbs-voidzero-and-astro-becoming-default-path-agent-apps.mdx`

/schedule 2026-06-23 09:00

Checks:
- `npm run check:types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published a previously hidden blog post, making it available to readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->