### PR TITLE
Schedule markdown data notebooks post

### DIFF
--- a/public/images/blog/2026/markdown-data-notebooks/chart-01-weather-condition-distribution.svg
+++ b/public/images/blog/2026/markdown-data-notebooks/chart-01-weather-condition-distribution.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="750" height="450">
+  <style>text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }</style>
+  <rect width="100%" height="100%" fill="white"/>
+  <text x="375" y="28" text-anchor="middle" font-size="16" font-weight="600">Weather condition distribution</text>
+  <path d="M 375 235 L 375 115 A 120 120 0 0 1 381.9488157231434 354.79863922451625 Z" fill="#4a90d9" stroke="white" stroke-width="2"/>
+  <path d="M 375 235 L 381.9488157231434 354.79863922451625 A 120 120 0 0 1 288.5243441653617 151.80167701227873 Z" fill="#50c878" stroke="white" stroke-width="2"/>
+  <path d="M 375 235 L 288.5243441653617 151.80167701227873 A 120 120 0 0 1 338.99717640320966 120.5281838483446 Z" fill="#f4a460" stroke="white" stroke-width="2"/>
+  <path d="M 375 235 L 338.99717640320966 120.5281838483446 A 120 120 0 0 1 375 115 Z" fill="#da70d6" stroke="white" stroke-width="2"/>
+  <path d="M 494.94964924280094 231.52413370092762 L 529.9349636052846 230.5103393636982 L 525 230.5103393636982" fill="none" stroke="#4a90d9" stroke-width="1.5"/>
+  <circle cx="494.94964924280094" cy="231.52413370092762" r="2" fill="#4a90d9"/>
+  <text x="525" y="234.5103393636982" text-anchor="start" font-size="10" fill="#4a90d9" font-weight="500">rain (49.1%)</text>
+  <path d="M 265.99049930680826 285.1690019695532 L 225 285.1690019695532" fill="none" stroke="#50c878" stroke-width="1.5"/>
+  <circle cx="265.99049930680826" cy="285.1690019695532" r="2" fill="#50c878"/>
+  <text x="225" y="289.1690019695532" text-anchor="end" font-size="10" fill="#50c878" font-weight="500">cloudy (38.1%)</text>
+  <path d="M 311.7959469287975 132.9938841276043 L 299.681836756817 113.44271191872846 L 225 113.44271191872846" fill="none" stroke="#f4a460" stroke-width="1.5"/>
+  <circle cx="311.7959469287975" cy="132.9938841276043" r="2" fill="#f4a460"/>
+  <text x="225" y="117.44271191872846" text-anchor="end" font-size="10" fill="#f4a460" font-weight="500">clear (8.0%)</text>
+  <path d="M 356.7876132563391 116.39009750826314 L 351.47566712277137 81.79554261483989 L 225 81.79554261483989" fill="none" stroke="#da70d6" stroke-width="1.5"/>
+  <circle cx="356.7876132563391" cy="116.39009750826314" r="2" fill="#da70d6"/>
+  <text x="225" y="85.79554261483989" text-anchor="end" font-size="10" fill="#da70d6" font-weight="500">snow (4.8%)</text>
+</svg>

--- a/public/images/blog/2026/markdown-data-notebooks/chart-02-total-precipitation-by-month.svg
+++ b/public/images/blog/2026/markdown-data-notebooks/chart-02-total-precipitation-by-month.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="540" viewBox="0 0 700 540">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  </style>
+  <rect width="100%" height="100%" fill="white"/>
+  <text x="350" y="28" text-anchor="middle" font-size="16" font-weight="600">Total precipitation by month</text>
+  <g transform="translate(0, 50)">
+    <g transform="translate(0, 0)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-01</text>
+      <rect x="180" y="0" width="369.74559686888455" height="30" fill="#4a90d9" rx="3"/>
+      <text x="557.7455968688846" y="20" font-size="12" fill="#333">944.7</text>
+    </g>
+    <g transform="translate(0, 40)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-02</text>
+      <rect x="180" y="0" width="221.29158512720153" height="30" fill="#50c878" rx="3"/>
+      <text x="409.29158512720153" y="20" font-size="12" fill="#333">565.4</text>
+    </g>
+    <g transform="translate(0, 80)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-03</text>
+      <rect x="180" y="0" width="427.7103718199608" height="30" fill="#f4a460" rx="3"/>
+      <text x="615.7103718199608" y="20" font-size="12" fill="#333">1092.8</text>
+    </g>
+    <g transform="translate(0, 120)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-04</text>
+      <rect x="180" y="0" width="299.9608610567514" height="30" fill="#da70d6" rx="3"/>
+      <text x="487.9608610567514" y="20" font-size="12" fill="#333">766.4</text>
+    </g>
+    <g transform="translate(0, 160)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-05</text>
+      <rect x="180" y="0" width="368.53228962818" height="30" fill="#20b2aa" rx="3"/>
+      <text x="556.53228962818" y="20" font-size="12" fill="#333">941.6</text>
+    </g>
+    <g transform="translate(0, 200)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-06</text>
+      <rect x="180" y="0" width="319.37377690802344" height="30" fill="#ff6b6b" rx="3"/>
+      <text x="507.37377690802344" y="20" font-size="12" fill="#333">816</text>
+    </g>
+    <g transform="translate(0, 240)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-07</text>
+      <rect x="180" y="0" width="241.252446183953" height="30" fill="#4ecdc4" rx="3"/>
+      <text x="429.252446183953" y="20" font-size="12" fill="#333">616.4</text>
+    </g>
+    <g transform="translate(0, 280)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-08</text>
+      <rect x="180" y="0" width="351.5068493150685" height="30" fill="#95a5a6" rx="3"/>
+      <text x="539.5068493150685" y="20" font-size="12" fill="#333">898.1</text>
+    </g>
+    <g transform="translate(0, 320)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-09</text>
+      <rect x="180" y="0" width="266.692759295499" height="30" fill="#4a90d9" rx="3"/>
+      <text x="454.692759295499" y="20" font-size="12" fill="#333">681.4</text>
+    </g>
+    <g transform="translate(0, 360)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-10</text>
+      <rect x="180" y="0" width="236.94716242661448" height="30" fill="#50c878" rx="3"/>
+      <text x="424.94716242661445" y="20" font-size="12" fill="#333">605.4</text>
+    </g>
+    <g transform="translate(0, 400)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-11</text>
+      <rect x="180" y="0" width="440" height="30" fill="#f4a460" rx="3"/>
+      <text x="628" y="20" font-size="12" fill="#333">1124.2</text>
+    </g>
+    <g transform="translate(0, 440)">
+      <text x="170" y="20" text-anchor="end" font-size="13">2024-12</text>
+      <rect x="180" y="0" width="295.18590998043055" height="30" fill="#da70d6" rx="3"/>
+      <text x="483.18590998043055" y="20" font-size="12" fill="#333">754.2</text>
+    </g>
+  </g>
+</svg>

--- a/public/images/blog/2026/markdown-data-notebooks/chart-03-average-temperature-by-city.svg
+++ b/public/images/blog/2026/markdown-data-notebooks/chart-03-average-temperature-by-city.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="380" viewBox="0 0 700 380">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+  </style>
+  <rect width="100%" height="100%" fill="white"/>
+  <text x="350" y="28" text-anchor="middle" font-size="16" font-weight="600">Average temperature by city</text>
+  <g transform="translate(0, 50)">
+    <g transform="translate(0, 0)">
+      <text x="170" y="20" text-anchor="end" font-size="13">Singapore</text>
+      <rect x="180" y="0" width="440" height="30" fill="#4a90d9" rx="3"/>
+      <text x="628" y="20" font-size="12" fill="#333">27.6</text>
+    </g>
+    <g transform="translate(0, 40)">
+      <text x="170" y="20" text-anchor="end" font-size="13">Cairo</text>
+      <rect x="180" y="0" width="384.2028985507246" height="30" fill="#50c878" rx="3"/>
+      <text x="572.2028985507246" y="20" font-size="12" fill="#333">24.1</text>
+    </g>
+    <g transform="translate(0, 80)">
+      <text x="170" y="20" text-anchor="end" font-size="13">Buenos Aires</text>
+      <rect x="180" y="0" width="282.17391304347825" height="30" fill="#f4a460" rx="3"/>
+      <text x="470.17391304347825" y="20" font-size="12" fill="#333">17.7</text>
+    </g>
+    <g transform="translate(0, 120)">
+      <text x="170" y="20" text-anchor="end" font-size="13">Tokyo</text>
+      <rect x="180" y="0" width="266.231884057971" height="30" fill="#da70d6" rx="3"/>
+      <text x="454.231884057971" y="20" font-size="12" fill="#333">16.7</text>
+    </g>
+    <g transform="translate(0, 160)">
+      <text x="170" y="20" text-anchor="end" font-size="13">Istanbul</text>
+      <rect x="180" y="0" width="258.2608695652174" height="30" fill="#20b2aa" rx="3"/>
+      <text x="446.2608695652174" y="20" font-size="12" fill="#333">16.2</text>
+    </g>
+    <g transform="translate(0, 200)">
+      <text x="170" y="20" text-anchor="end" font-size="13">New York</text>
+      <rect x="180" y="0" width="207.2463768115942" height="30" fill="#ff6b6b" rx="3"/>
+      <text x="395.2463768115942" y="20" font-size="12" fill="#333">13</text>
+    </g>
+    <g transform="translate(0, 240)">
+      <text x="170" y="20" text-anchor="end" font-size="13">London</text>
+      <rect x="180" y="0" width="186.52173913043475" height="30" fill="#4ecdc4" rx="3"/>
+      <text x="374.52173913043475" y="20" font-size="12" fill="#333">11.7</text>
+    </g>
+    <g transform="translate(0, 280)">
+      <text x="170" y="20" text-anchor="end" font-size="13">Reykjavik</text>
+      <rect x="180" y="0" width="62.17391304347826" height="30" fill="#95a5a6" rx="3"/>
+      <text x="250.17391304347825" y="20" font-size="12" fill="#333">3.9</text>
+    </g>
+  </g>
+</svg>

--- a/src/content/blog/2026/2026-06-30-building-tiny-data-notebooks-with-markdown-sqlite-and-csvs.mdx
+++ b/src/content/blog/2026/2026-06-30-building-tiny-data-notebooks-with-markdown-sqlite-and-csvs.mdx
@@ -1,0 +1,203 @@
+---
+title: "Building Tiny Data Notebooks With Markdown, SQLite, and CSVs"
+description: "A small local notebook workflow for CSV reports: pull public data, load it into SQLite, write SQL inside Markdown, and generate a static HTML report with charts."
+date: 2026-06-30
+slug: "building-tiny-data-notebooks-with-markdown-sqlite-and-csvs"
+tags: ["markdown", "sqlite", "csv", "data", "nodejs"]
+social_post: |
+  I built a tiny data notebook workflow with Markdown, SQLite, and CSVs: public weather data in, SQL-in-Markdown templates out, with generated HTML reports and charts you can host on GitHub Pages.
+---
+
+import ImageZoom from "@components/ImageZoom.astro";
+
+AI agents changed what I expect from small data reports.
+
+It is now totally reasonable to hand an agent a CSV and ask for a nice HTML analysis with charts. For quick one-offs, that is hard to beat. But I do not want every report to become the reporting style du jour: a disposable blob of generated HTML.
+
+If I need to rerun the report next week, change one query, inspect the data myself, or reuse a chart in a presentation, I want the repeatable parts to stay repeatable: source CSVs, SQL queries, report templates, and chart generation.
+
+I also do not want the setup to immediately turn into a Python/Jupyter environment, a dashboard app, or a dev server I have to keep running. Those are good tools when the job asks for them. For this shape, they feel heavier than necessary.
+
+And ideally, the whole thing should not need a pile of npm packages just to turn CSVs into tables and SVGs.
+
+So I built a tiny notebook workflow with Markdown, SQLite, CSVs, and plain Node.js.
+
+I made a small public repo for it here: [markdown-data-notebooks](https://github.com/mfyz/markdown-data-notebooks). The generated report has a [Markdown version GitHub can preview directly](https://github.com/mfyz/markdown-data-notebooks/blob/main/reports/weather_report.md), and an [HTML version hosted on GitHub Pages](https://mfyz.github.io/markdown-data-notebooks/reports/weather_report.html).
+
+## The shape I wanted
+
+I wanted something that felt like a notebook, but stayed close to normal developer tooling.
+
+The workflow should be:
+
+```mermaid
+%% width=760 center
+flowchart LR
+  Pull["pull public<br/>data"] --> CSV["write CSV<br/>files"]
+  CSV --> DB["build SQLite<br/>DB"]
+  DB --> SQL["run SQL<br/>blocks"]
+  SQL --> Report["generate Markdown<br/>+ HTML report"]
+```
+
+That is it.
+
+No dashboard server. No notebook runtime. No database service. No npm dependencies. Just a local repo with scripts and templates.
+
+The approach I came up with is simple: Markdown is the document surface, SQLite is the query engine, and CSVs are input tables. Because SQLite sits in the middle, the data can be one CSV or multiple CSVs joined together. The output blocks can be tables or charts, but the report stays described in plain Markdown.
+
+Here is how that looks. A table is a fenced SQL block inside the Markdown file:
+
+````markdown
+```sql:table
+SELECT
+  city AS "City",
+  avg_temp_c AS "Avg C",
+  total_precipitation_mm AS "Rain mm"
+FROM location_weather_summary
+ORDER BY avg_temp_c DESC
+```
+````
+
+The generator executes that SQL against the local SQLite database and replaces the block with a Markdown table. The same idea works for charts:
+
+````markdown
+```sql:bar-chart(title="Average temperature by city")
+SELECT
+  city AS label,
+  avg_temp_c AS value
+FROM location_weather_summary
+ORDER BY avg_temp_c DESC
+```
+````
+
+This is not a new idea. Literate programming, notebooks, static site generators, and SQL-based BI tools all orbit around the same pattern. What I wanted was a tiny version that fits in a repo and can be understood in one sitting.
+
+## Why weather data
+
+I wanted demo data that was public, familiar, and still interesting enough for charts. Weather is perfect for that.
+
+The seed script pulls city metadata from the [Open-Meteo Geocoding API](https://open-meteo.com/en/docs/geocoding-api), then pulls daily 2024 weather data from the [Open-Meteo Historical Weather API](https://open-meteo.com/en/docs/historical-weather-api). That gives the repo two CSV files:
+
+- `locations.csv` has city, country, coordinates, timezone, elevation, and population.
+- `daily_weather.csv` has one row per city per day with weather code, temperature, precipitation, and wind speed.
+
+Those two files give enough shape to demonstrate joins, filters, summaries, tables, bar charts, and pie charts without needing a private export.
+
+The first summary table is basic, but that is exactly the point. A couple of local CSV files are enough to ask useful questions.
+
+<ImageZoom
+  src="/images/blog/2026/markdown-data-notebooks/chart-03-average-temperature-by-city.svg"
+  alt="Bar chart showing average 2024 temperature by city for Singapore, Cairo, Buenos Aires, Tokyo, Istanbul, New York, London, and Reykjavik"
+/>
+
+This is the kind of chart I want in a report. Not a full dashboard, not a visualization project. Just enough visual structure to make the pattern obvious.
+
+## The database step
+
+The project uses SQLite as the small query engine in the middle.
+
+Historically I would have reached for `better-sqlite3` or `sql.js`. Both are good choices. For this experiment, though, I wanted the repo to be completely dependency-free, so I used Node's built-in [`node:sqlite`](https://nodejs.org/api/sqlite.html) module.
+
+That choice has a trade-off. `node:sqlite` is available in modern Node, but it is still relatively new. For a production package, I would think harder about version support and whether an established SQLite package is the better bet. For a small demonstration repo, having zero npm packages is nice.
+
+The database build step reads every CSV in `data/source`, creates a table for each one, infers basic column types, inserts the rows, and then creates a few views:
+
+```text
+daily_weather
+locations
+weather_daily_enriched
+location_weather_summary
+monthly_weather_summary
+condition_summary
+```
+
+The join happens in `weather_daily_enriched`:
+
+```sql
+SELECT
+  w.location_id,
+  l.city,
+  l.country,
+  w.date,
+  w.weather_code,
+  w.temp_mean_c,
+  w.precipitation_mm
+FROM daily_weather w
+JOIN locations l ON l.location_id = w.location_id
+```
+
+Once the data is in SQLite, the rest of the workflow is normal SQL.
+
+## Charts are just SVG files
+
+I did not want to pull in a charting library for this. The report generator has two small SVG helpers: one for horizontal bar charts, one for pie charts.
+
+That is intentionally limited. But limited is fine here.
+
+This report does not need hover states, legends, filters, or drill-downs. It needs a few charts that render in Markdown/HTML and can be committed with the report.
+
+Here is the monthly precipitation chart generated from the `monthly_weather_summary` view:
+
+<ImageZoom
+  src="/images/blog/2026/markdown-data-notebooks/chart-02-total-precipitation-by-month.svg"
+  alt="Bar chart showing total precipitation by month across the demo weather dataset"
+/>
+
+The SQL behind it is simple:
+
+```sql
+SELECT
+  month AS label,
+  ROUND(SUM(precipitation_mm), 1) AS value
+FROM monthly_weather_summary
+GROUP BY month
+ORDER BY month
+```
+
+That is the part I like. The chart is not configured somewhere else. It lives next to the explanation, inside the report template.
+
+## The report is static
+
+The generator writes two files:
+
+```text
+reports/weather_report.md
+reports/weather_report.html
+```
+
+The Markdown version is useful in the repo. The HTML version is useful for sharing. Since the output is static, GitHub Pages can host it without any server code.
+
+The generated outputs are here:
+
+- [Markdown report previewed by GitHub](https://github.com/mfyz/markdown-data-notebooks/blob/main/reports/weather_report.md)
+- [HTML report hosted on GitHub Pages](https://mfyz.github.io/markdown-data-notebooks/reports/weather_report.html)
+
+That makes the workflow easy to explain:
+
+```bash
+npm run seed
+npm run report
+```
+
+Then commit the generated report if you want to publish it.
+
+## Where this fits
+
+I would reach for this when the job is recurring but still small.
+
+That could be weekly exports, public datasets, simple analytics, operational summaries, or reports where the question is mostly "what changed?" or "what are the top patterns?" The report itself stays reviewable too: the template is Markdown, the SQL is visible, the generated report is a file, and the charts are SVGs.
+
+The weather condition distribution is a good example. It is not trying to be fancy. It gives a quick shape of the dataset, which is usually enough for a report you want to read, not operate.
+
+<ImageZoom
+  src="/images/blog/2026/markdown-data-notebooks/chart-01-weather-condition-distribution.svg"
+  alt="Pie chart showing distribution of weather condition groups in the demo weather dataset"
+/>
+
+This is not a replacement for Jupyter. If you need interactive exploration, statistical notebooks, rich plotting, or a data science workflow, use the real thing. It is also not a dashboard. There is no live filtering, no user accounts, no refresh loop, and no incremental query engine behind a UI.
+
+SQL inside Markdown can get ugly if you let it. My rule would be: keep the template queries readable. If the SQL starts turning into an application, move that complexity into views or scripts. Same with CSV parsing: this repo handles normal quoted CSV, but if the input format gets hostile, use a real CSV library.
+
+The reason I like this pattern is not that it is technically impressive. It is the opposite. I can read the scripts, inspect the CSVs, run the SQL manually, and open the generated Markdown or HTML report without keeping anything alive in the background.
+
+I will probably keep this as a small starter for future CSV-heavy posts. It sits in a nice middle ground: more repeatable than a spreadsheet, much lighter than a notebook environment, and plain enough that the whole thing can live in Git.


### PR DESCRIPTION
Publishes the markdown data notebooks blog post on the next Tuesday slot after the currently scheduled June 23 post.

Post file:
`src/content/blog/2026/2026-06-30-building-tiny-data-notebooks-with-markdown-sqlite-and-csvs.mdx`

/schedule 2026-06-30 09:00

Checks:
- `npm run check:types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new blog post documenting a workflow for creating data notebooks using Markdown, SQLite, and CSV files with static report generation and embedded SQL visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->